### PR TITLE
real time face example updates

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,98 @@
+---
+Language:        Cpp
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+BreakBeforeInheritanceComma: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/3rdparty/drishti"]
 	path = src/3rdparty/drishti
 	url = https://github.com/elucideye/drishti.git
+[submodule "src/3rdparty/ogles_gpgpu"]
+	path = src/3rdparty/ogles_gpgpu
+	url = https://github.com/hunter-packages/ogles_gpgpu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,28 +31,36 @@ cmake_minimum_required(VERSION 3.9)
 # https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-keep-package-sources
 option(HUNTER_KEEP_PACKAGE_SOURCES "Keep installed package sources for debugging (caveat...)" ON)
 
-option(DRISHTI_USE_DRISHTI_UPLOAD "Use drishti upload configuration" OFF)
-if(DRISHTI_USE_DRISHTI_UPLOAD)
-  include("${CMAKE_CURRENT_LIST_DIR}/cmake/upload.cmake")
-endif()
+#########################
+### CMAKE_MODULE_PATH ###
+#########################
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
 ############################
 ### HunterGate and cache ###
 ############################
 
-option(DRISHTI_AS_SUBMODULE "Include drishti as a submodule" ON)
-
 include("cmake/HunterGate.cmake")
 HunterGate(
   URL "https://github.com/ruslo/hunter/archive/v0.20.48.tar.gz"
   SHA1 "758836c69d9ecb7a773b8e4b64e25d0fa4e76582"
-  LOCAL # Note config.cmake includes ${WORKING_CONFIG}
+  LOCAL
   )
 
 option(DRISHTI_TEST_BUILD_MIN_SIZE "Toggle minsize (predict only) builds" ON)
 option(DRISHTI_TEST_BUILD_TESTS "Build cross platform tests" OFF)
+option(DRISHTI_OPENGL_ES3 "Support OpenGL ES 3.0 (default 2.0)" OFF)
 
 project(drishti-hunter-test)
+
+######################
+### RPATH defaults ###
+######################
+
+# see: http://www.cmake.org/Wiki/CMake_RPATH_handling
+include(drishti_set_rpath)
+drishti_set_rpath()
 
 ###############
 ### drishti ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ cmake_minimum_required(VERSION 3.9)
 # https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-keep-package-sources
 option(HUNTER_KEEP_PACKAGE_SOURCES "Keep installed package sources for debugging (caveat...)" ON)
 
+# configure the cache upload
+# NOTE: This runs only during CI builds on travis and appveyor
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/upload.cmake")
+
 #########################
 ### CMAKE_MODULE_PATH ###
 #########################

--- a/bin/build-appveyor.cmd
+++ b/bin/build-appveyor.cmd
@@ -10,11 +10,13 @@ echo POLLY_ROOT %POLLY_ROOT%
 
 python %POLLY_ROOT%\bin\polly.py ^
 --verbose ^
---archive drishti ^
+--archive drishti_hunter_test ^
 --config "%1%" ^
 --toolchain "%2%" ^
+--jobs 2 ^            
 --test ^
 --fwd HUNTER_USE_CACHE_SERVERS=YES ^
 HUNTER_DISABLE_BUILDS=NO ^
-HUNTER_SUPPRESS_LIST_OF_FILES=ON ^
-DRISHTI_USE_DRISHTI_UPLOAD=ON
+HUNTER_CONFIGURATION_TYPES="%1%" ^
+HUNTER_SUPPRESS_LIST_OF_FILES=ON
+

--- a/bin/build-appveyor.cmd
+++ b/bin/build-appveyor.cmd
@@ -13,10 +13,9 @@ python %POLLY_ROOT%\bin\polly.py ^
 --archive drishti_hunter_test ^
 --config "%1%" ^
 --toolchain "%2%" ^
---jobs 2 ^            
+--jobs 2 ^
 --test ^
 --fwd HUNTER_USE_CACHE_SERVERS=YES ^
 HUNTER_DISABLE_BUILDS=NO ^
 HUNTER_CONFIGURATION_TYPES="%1%" ^
 HUNTER_SUPPRESS_LIST_OF_FILES=ON
-

--- a/bin/build-travis.sh
+++ b/bin/build-travis.sh
@@ -17,8 +17,12 @@ args=(
     --archive drishti_hunter_test
     --jobs 2
     --test
-    --verbose
     ${INSTALL}
 )
+
+# Skip --verbose on Android (log is too long)
+if [[ ! $name =~ ^android-.* ]]; then 
+    args+=(--verbose)
+fi
 
 polly.py ${args[@]}

--- a/bin/build-travis.sh
+++ b/bin/build-travis.sh
@@ -17,12 +17,10 @@ args=(
     --archive drishti_hunter_test
     --jobs 2
     --test
+    --verbose
+    --discard 10
+    --tail 512
     ${INSTALL}
 )
-
-# Skip --verbose on Android (log is too long)
-if [[ ! $name =~ ^android-.* ]]; then 
-    args+=(--verbose)
-fi
 
 polly.py ${args[@]}

--- a/bin/build-travis.sh
+++ b/bin/build-travis.sh
@@ -12,11 +12,12 @@ args=(
     GAUZE_ANDROID_USE_EMULATOR=YES
     HUNTER_USE_CACHE_SERVERS=YES
     HUNTER_DISABLE_BUILDS=NO
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
     HUNTER_SUPPRESS_LIST_OF_FILES=ON
-    DRISHTI_USE_DRISHTI_UPLOAD=ON
     --archive drishti_hunter_test
     --jobs 2
     --test
+    --verbose
     ${INSTALL}
 )
 

--- a/bin/drishti-format.sh
+++ b/bin/drishti-format.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Note: When using clang-format the ${DRISHTISDK}/.clang-format file
+# seems to be ignored if the root directory to this script is not
+# specified relative to the working directory:
+#
+# Suggested usage:
+#
+# cd ${DRISHTISDK}
+# ./bin/drishti-format.sh src/lib
+# ./bin/drishti-format.sh src/app
+# ./bin/drishti-format.sh src/test
+
+if [ -z "${DRISHTISDK}" ]; then
+    echo 2>&1 "Must have DRISHTISDK set"
+fi
+
+# Find all internal files, making sure to exlude 3rdparty subprojects
+function find_drishti_source()
+{
+    NAMES=(-name "*.h" -or -name "*.cpp" -or -name "*.hpp" -or -name "*.m" -or -name "*.mm")
+    find $1 -not \( -path ${DRISHTISDK}/src/3rdparty -prune \) ${NAMES[@]}
+}
+
+#input_dir=${DRISHTISDK}/src
+input_dir=$1
+
+echo ${input_dir}
+
+find_drishti_source ${input_dir} | grep -v "src/3rdparty" | while read name
+do
+    echo $name
+    #astyle --style=allman --add-brackets --indent-switches $name
+    clang-format -i -style=file ${name}
+done
+
+

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -33,7 +33,13 @@ hunter_config(acf VERSION ${HUNTER_acf_VERSION} CMAKE_ARGS ${acf_cmake_args})
 # ogles_gpgpu
 ##############################################
 
-option(DHT_OGLES_GPGPU_AS_SUBMODULE "Include ogles_gpgpu as a submodule" ON)
+if(APPLE AND NOT IOS) # temporary workaround on osx platform
+  set(dht_ogles_gpgpu_submodule ON)
+else()
+  set(dht_ogles_gpgpu_submodule OFF)
+endif()
+
+option(DHT_OGLES_GPGPU_AS_SUBMODULE "Include ogles_gpgpu as a submodule" ${dht_ogles_gpgpu_submodule})
 
 set(ogles_gpgpu_cmake_args
   OGLES_GPGPU_OPENGL_ES3=${DRISHTI_OPENGL_ES3}

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,4 +1,7 @@
-### Configure XGBOOST w/ cereal ###
+##############################################
+# xgboost
+##############################################
+
 set(XGBOOST_CMAKE_ARGS
   XGBOOST_USE_HALF=ON
   XGBOOST_USE_CEREAL=ON
@@ -10,6 +13,12 @@ else()
 endif()
 hunter_config(xgboost VERSION 0.40-p10 CMAKE_ARGS ${XGBOOST_CMAKE_ARGS})
 
+##############################################
+# acf
+##############################################
+
+# note: currently acf depends on ogles_gpgpu OpenGL version
+# -- there is no ACF_OPENGL_ES3
 set(acf_cmake_args
   ACF_BUILD_TESTS=OFF 
   ACF_BUILD_EXAMPLES=OFF
@@ -20,6 +29,28 @@ set(acf_cmake_args
 )
 hunter_config(acf VERSION ${HUNTER_acf_VERSION} CMAKE_ARGS ${acf_cmake_args})
 
+##############################################
+# ogles_gpgpu
+##############################################
+
+option(DHT_OGLES_GPGPU_AS_SUBMODULE "Include ogles_gpgpu as a submodule" ON)
+
+set(ogles_gpgpu_cmake_args
+  OGLES_GPGPU_OPENGL_ES3=${DRISHTI_OPENGL_ES3}
+)
+if(DHT_OGLES_GPGPU_AS_SUBMODULE)
+  if(NOT EXISTS "src/3rdparty/ogles_gpgpu")
+    message(FATAL_ERROR "src/3rdparty/ogles_gpgpu submodule was requested, but does not exist")
+  endif()
+  hunter_config(ogles_gpgpu GIT_SUBMODULE "src/3rdparty/ogles_gpgpu" CMAKE_ARGS ${ogles_gpgpu_cmake_args})
+else()
+  hunter_config(ogles_gpgpu VERSION ${HUNTER_ogles_gpgpu_VERSION} CMAKE_ARGS ${ogles_gpgpu_cmake_args})
+endif()
+
+##############################################
+# eigen
+##############################################
+
 set(eigen_cmake_args
   BUILD_TESTING=OFF
   HUNTER_INSTALL_LICENSE_FILES=COPYING.MPL2
@@ -27,10 +58,37 @@ set(eigen_cmake_args
 )
 hunter_config(Eigen VERSION ${HUNTER_Eigen_VERSION} CMAKE_ARGS ${eigen_cmake_args})
 
-### Configure drishti as submodule ###
-if(DRISHTI_AS_SUBMODULE)
-  hunter_config(drishti GIT_SUBMODULE "src/3rdparty/drishti")
+##############################################
+# aglet
+##############################################
+
+set(aglet_cmake_args
+  AGLET_OPENGL_ES3=${DRISHTI_OPENGL_ES3}
+)
+hunter_config(aglet VERSION ${HUNTER_aglet_VERSION} CMAKE_ARGS ${aglet_cmake_args})
+
+##############################################
+# drishti
+##############################################
+
+option(DHT_DRISHTI_AS_SUBMODULE "Include drishti as a submodule" ON)
+
+set(drishti_cmake_args
+  DRISHTI_BUILD_SHARED_SDK=OFF
+  DRISHTI_OPENGL_ES3=${DRISHTI_OPENGL_ES3}
+)
+if(DHT_DRISHTI_AS_SUBMODULE)
+  if(NOT EXISTS "src/3rdparty/drishti")
+    message(FATAL_ERROR "src/3rdparty/drishti submodule was requested, but does not exist")
+  endif()  
+  hunter_config(drishti GIT_SUBMODULE "src/3rdparty/drishti" CMAKE_ARGS ${drishti_cmake_args})
+else()
+  hunter_config(drishti VERSION ${HUNTER_drishti_VERSION} CMAKE_ARGS ${drishti_cmake_args})
 endif()
+
+##############################################
+# OpenCV
+##############################################
 
 string(COMPARE EQUAL "${CMAKE_OSX_SYSROOT}" "iphoneos" _is_ios)
 
@@ -121,6 +179,10 @@ set(opencv_cmake_args
 
 hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS ${opencv_cmake_args})
 
+##############################################
+# dlib
+##############################################
+
 set(dlib_cmake_args
   DLIB_HEADER_ONLY=OFF  #all previous builds were header on, so that is the default
   DLIB_ENABLE_ASSERTS=OFF #must be set on/off or debug/release build will differ and config will not match one
@@ -142,12 +204,23 @@ set(dlib_cmake_args
 if(ANDROID)
   # * https://github.com/ruslo/hunter/commit/08d25c51e8fa3f3fcfa73f655fe3a7d85d1b4109
   set(dlib_version VERSION 19.2-p1)
-  # * error: 'struct lconv' has no member named 'decimal_point'
-  set(nlohmann_json_version VERSION 2.1.1-p1)
 else()
   set(dlib_version ${HUNTER_dlib_VERSION})
-  set(nlohmann_json_version ${HUNTER_nlohmann_json_VERSION})  
 endif()
 
 hunter_config(dlib VERSION ${dlib_version} CMAKE_ARGS ${dlib_cmake_args})
+
+##############################################
+# nlohmann_json
+##############################################
+
+# Workarounds for partial c++11 in ndk10e + gcc toolchains:
+# TODO: This could be managed by try_compile tests, but won't be needed after ndk17
+if(ANDROID)
+  # * error: 'struct lconv' has no member named 'decimal_point'
+  set(nlohmann_json_version VERSION 2.1.1-p1)
+else()
+  set(nlohmann_json_version ${HUNTER_nlohmann_json_VERSION})  
+endif()
+
 hunter_config(nlohmann_json VERSION ${nlohmann_json_version})

--- a/cmake/Modules/drishti_set_rpath.cmake
+++ b/cmake/Modules/drishti_set_rpath.cmake
@@ -1,0 +1,9 @@
+#https://cmake.org/Wiki/CMake_RPATH_handling
+
+macro(drishti_set_rpath)
+  set(DRISHTI_ORIGIN "$ORIGIN")
+  if (APPLE)
+    set(DRISHTI_ORIGIN "@loader_path")
+  endif()
+  set(CMAKE_INSTALL_RPATH "${DRISHTI_ORIGIN}/../lib:${DRISHTI_ORIGIN}/")
+endmacro()

--- a/src/app/eye/drishti-eye-test.cpp
+++ b/src/app/eye/drishti-eye-test.cpp
@@ -21,18 +21,18 @@
 
 #include <fstream>
 
-static std::shared_ptr<spdlog::logger> createLogger(const char *name);
+static std::shared_ptr<spdlog::logger> createLogger(const char* name);
 
-int gauze_main(int argc, char **argv)
+int gauze_main(int argc, char** argv)
 {
     const auto argumentCount = argc;
 
     bool isRight = false;
     bool isLeft = false;
     std::string sInput, sOutput, sModel;
-    
+
     cxxopts::Options options("drishti-eye-test", "Command line interface for eye model fitting");
-    
+
     // clang-format off
     options.add_options()
         // input/output:

--- a/src/app/face/AsyncWorker.h
+++ b/src/app/face/AsyncWorker.h
@@ -1,0 +1,81 @@
+/*!
+  @file   AsyncWorker
+  @author David Hirvonen
+  @brief  Simple asynchronous worker (1 item job queue)
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#include <mutex>
+#include <condition_variable>
+
+#ifndef __AsyncWorker_h__
+#define __AsyncWorker_h__
+
+template <typename Callable>
+struct AsyncWorker
+{
+    void loop()
+    {
+        while (running)
+        {
+            // Wait until main() sends data:
+            std::unique_lock<std::mutex> lock(mutex);
+            cv.wait(lock, [this] { return this->ready; });
+
+            // call the callback/lambda:
+            action();
+            ready = false;
+            processed = true;
+
+            // Manual unlocking is done before notifying, to avoid waking up
+            // the waiting thread only to block again (see notify_one for details):
+            lock.unlock();
+            cv.notify_one();
+        }
+    }
+
+    void start()
+    {
+        worker = std::thread([&] { loop(); });
+    }
+
+    void stop()
+    {
+        running = false;
+        post([] {}); // post sentinel
+    }
+
+    void post(const Callable& callback)
+    {
+        action = callback;
+
+        // send data to the worker thread:
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            ready = true;
+        }
+        cv.notify_one();
+
+        // wait for the worker:
+        {
+            std::unique_lock<std::mutex> lock(mutex);
+            cv.wait(lock, [this] { return this->processed; });
+        }
+    }
+
+    // Synchronization {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool ready = false;
+    bool processed = false;
+    std::thread worker;
+    Callable action;
+
+    bool running = true;
+    //  }
+};
+
+#endif // __AsyncWorker_h__

--- a/src/app/face/CMakeLists.txt
+++ b/src/app/face/CMakeLists.txt
@@ -12,7 +12,17 @@ hunter_add_package(Boost COMPONENTS system filesystem)
 find_package(Boost CONFIG REQUIRED system filesystem)
 set(boost_libs Boost::system Boost::filesystem)
 
-add_executable(drishti-face-test drishti-face-test.cpp FaceTrackerFactoryJson.h FaceTrackerFactoryJson.cpp)
+add_executable(drishti-face-test 
+  AsyncWorker.h
+  FaceTrackerFactoryJson.cpp
+  FaceTrackerFactoryJson.h
+  FaceTrackerTest.cpp
+  FaceTrackerTest.h
+  VideoCaptureList.cpp
+  VideoCaptureList.h
+  drishti-face-test.cpp
+)
+
 target_link_libraries(drishti-face-test PUBLIC ${base_deps} nlohmann_json aglet::aglet ${boost_libs})
 if(DRISHTI_TEST_BUILD_TESTS)
   target_compile_definitions(drishti-face-test PUBLIC DRISHTI_TEST_BUILD_TESTS=1)

--- a/src/app/face/FaceTrackerFactoryJson.cpp
+++ b/src/app/face/FaceTrackerFactoryJson.cpp
@@ -14,7 +14,7 @@
 
 // Need std:: extensions for android targets
 #if defined(DRISHTI_HUNTER_TEST_ADD_TO_STRING)
-#  include "stdlib_string.h"
+#include "stdlib_string.h"
 #endif
 
 #include <nlohmann/json.hpp> // nlohman-json
@@ -23,9 +23,9 @@
 
 namespace bfs = boost::filesystem;
 
-static std::string cat(const std::string &a, const std::string &b) { return a + b; }
+static std::string cat(const std::string& a, const std::string& b) { return a + b; }
 
-FaceTrackerFactoryJson::FaceTrackerFactoryJson(const std::string &sModels, const std::string &logger)
+FaceTrackerFactoryJson::FaceTrackerFactoryJson(const std::string& sModels, const std::string& logger)
 {
     std::ifstream ifs(sModels);
     if (!ifs)
@@ -35,10 +35,9 @@ FaceTrackerFactoryJson::FaceTrackerFactoryJson(const std::string &sModels, const
 
     nlohmann::json json;
     ifs >> json;
-        
+
     factory.logger = logger; // logger name
-    std::vector< std::pair<const char *, std::istream **> > bindings =
-    {
+    std::vector<std::pair<const char*, std::istream**>> bindings = {
         { "face_detector", &factory.sFaceDetector },
         { "eye_model_regressor", &factory.sEyeRegressor },
         { "face_landmark_regressor", &factory.sFaceRegressor },
@@ -47,18 +46,18 @@ FaceTrackerFactoryJson::FaceTrackerFactoryJson(const std::string &sModels, const
 
     // Get the directory name:
     auto path = bfs::path(sModels);
-    for(auto &binding : bindings)
+    for (auto& binding : bindings)
     {
         auto filename = path.parent_path() / json[binding.first].get<std::string>();
         std::shared_ptr<std::istream> stream = std::make_shared<std::ifstream>(filename.string());
-        if(!stream || !stream->good())
+        if (!stream || !stream->good())
         {
             throw std::runtime_error(cat("FactoryLoader::FactoryLoader() failed to open ", binding.first));
         }
-            
-        (*binding.second) = stream.get();            
+
+        (*binding.second) = stream.get();
         streams.push_back(stream);
     }
-        
+
     good = true;
 }

--- a/src/app/face/FaceTrackerFactoryJson.h
+++ b/src/app/face/FaceTrackerFactoryJson.h
@@ -18,14 +18,14 @@
 class FaceTrackerFactoryJson
 {
 public:
-    FaceTrackerFactoryJson(const std::string &sModels, const std::string &logger);
+    FaceTrackerFactoryJson(const std::string& sModels, const std::string& logger);
     operator bool() const { return good; }
 
     drishti::sdk::FaceTracker::Resources factory;
-protected:
 
+protected:
     bool good = false;
-    std::vector<std::shared_ptr<std::istream>> streams; 
+    std::vector<std::shared_ptr<std::istream>> streams;
 };
 
 #endif // __drishti_face_FaceTrackerFactory_h__

--- a/src/app/face/FaceTrackerTest.cpp
+++ b/src/app/face/FaceTrackerTest.cpp
@@ -1,0 +1,303 @@
+/*!
+  @file   FaceTrackerTest.cpp
+  @author David Hirvonen
+  @brief  Sample eye/face tracking using drishti.
+
+  \copyright Copyright 2017-2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#include "FaceTrackerTest.h"
+#include "AsyncWorker.h"
+
+#include <ogles_gpgpu/common/proc/disp.h>
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/highgui.hpp>
+
+#include <iostream>
+#include <iomanip>
+
+namespace detail
+{
+template <typename Value, typename... Arguments>
+std::unique_ptr<Value> make_unique(Arguments&&... arguments_for_constructor)
+{
+    return std::unique_ptr<Value>(new Value(std::forward<Arguments>(arguments_for_constructor)...));
+}
+}
+
+static void draw(cv::Mat& image, const drishti::sdk::Eye& eye);
+static void draw(cv::Mat& image, const drishti::sdk::Face& face);
+
+struct FaceTrackTest::Impl
+{
+    Impl(std::shared_ptr<spdlog::logger>& logger, const std::string& output)
+        : logger(logger)
+        , output(output)
+        , counter(0)
+    {
+        worker.start();
+    }
+
+    ~Impl()
+    {
+        worker.stop();
+    }
+
+    // Preview methods {
+    void initPreview(const cv::Size& size, GLenum textureFormat)
+    {
+        display = std::make_shared<ogles_gpgpu::Disp>();
+        display->init(size.width, size.height, textureFormat);
+        display->setOutputRenderOrientation(ogles_gpgpu::RenderOrientationFlipped);
+    }
+
+    void setPreviewGeometry(float tx, float ty, float sx, float sy)
+    {
+        display->setOffset(tx, ty);
+        display->setDisplayResolution(sx, sy);
+    }
+
+    void updatePreview(std::uint32_t texture)
+    {
+        display->useTexture(texture);
+        display->render(0);
+    }
+    // }
+
+    std::shared_ptr<spdlog::logger> logger;
+    std::string output;
+    std::size_t counter;
+    cv::Size size; // video resolution
+
+    // Capture volume {
+    std::chrono::high_resolution_clock::time_point captureTimestamp;
+    double captureInterval = 0.0;
+    struct Sphere
+    {
+        std::array<float, 3> center;
+        float radius;
+    } sphere = { { { 0.f, 0.f, 0.f } }, 0.f };
+    // }
+
+    AsyncWorker<std::function<void()>> worker;
+
+    // This test class instantiates the ogles_gpgpu::Disp(lay) class in cases
+    // where the user has provided a context w/ a visible and active OpenGL window,
+    // and the display class will render directly to that screen.  The display
+    // class is instantiated here in the pimpl class because the inputs textures are
+    // available directly from the callbacks.   This could also be managed from a separate
+    // listener registered to the face tracker, but simplicity it is added here.
+    std::shared_ptr<ogles_gpgpu::Disp> display;
+};
+
+// See: https://github.com/elucideye/drishti/blob/master/src/lib/drishti/drishti/ut/test-FaceTracker.cpp
+FaceTrackTest::FaceTrackTest(std::shared_ptr<spdlog::logger>& logger, const std::string& sOutput)
+{
+    m_impl = detail::make_unique<Impl>(logger, sOutput);
+}
+
+FaceTrackTest::~FaceTrackTest() = default;
+
+void FaceTrackTest::initPreview(const cv::Size& size, GLenum textureFormat)
+{
+    m_impl->initPreview(size, textureFormat);
+}
+
+void FaceTrackTest::setPreviewGeometry(float tx, float ty, float sx, float sy)
+{
+    m_impl->setPreviewGeometry(tx, ty, sx, sy);
+}
+
+int FaceTrackTest::callback(drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results)
+{
+    m_impl->logger->info("callback: Received results");
+
+    if (results.size() > 0)
+    {
+        // Allocate a shared_ptr to store deep copies of the input data, so we can
+        // pass this one around easily to separate worker threads, etc.
+        auto stack = std::make_shared<StackType>(results.size());
+        for (int i = 0; i < results.size(); i++)
+        {
+            (*stack)[i].first = results[i];
+
+            const auto& r = results[i];
+            if (r.image.image.getRows() > 0 && r.image.image.getCols() > 0)
+            {
+                // IMPORTANT: Here we make a deep copy of hte input frame, since the requested image
+                // is passed by a pointer that is only valid for the scope of the callback.  In some
+                // cases the GPU->CPU transfer can be performed directly to pre-existing memory and
+                // the public SDK layer can optimize for this by using teh allocator callback so that
+                // memory can be allocated by the user/application layer.
+                (*stack)[i].second = drishti::sdk::drishtiToCv<drishti::sdk::Vec4b, cv::Vec4b>(r.image.image).clone();
+            }
+        }
+
+        // Send the stack to the user's process method via the asynchronous
+        // worker thread to avoid blocking in the main face tracker callback.
+        m_impl->worker.post([this, stack] { this->process(*stack); });
+    }
+
+    return 0;
+}
+
+void FaceTrackTest::setCaptureSphere(const std::array<float, 3>& center, float radius, double seconds)
+{
+    m_impl->sphere = { center, radius };
+    m_impl->captureInterval = seconds;
+}
+
+bool FaceTrackTest::shouldCapture(const drishti_face_tracker_result_t& faces)
+{
+    bool status = false;
+
+    if (m_impl->sphere.radius > 0.f)
+    {
+        // Comnpute simple/global FPS
+        const auto now = std::chrono::high_resolution_clock::now();
+        const double elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(now - m_impl->captureTimestamp).count();
+        if (elapsed > m_impl->captureInterval)
+        {
+            for (const auto& f : faces.faceModels)
+            {
+                const cv::Scalar center(m_impl->sphere.center[0], m_impl->sphere.center[1], m_impl->sphere.center[2]);
+                const float error = static_cast<float>(cv::norm(cv::Scalar(f.position[0], f.position[1], f.position[2]) - center));
+                m_impl->logger->info("Error {}", error);
+                if (error < m_impl->sphere.radius)
+                {
+                    status = true;
+                    m_impl->captureTimestamp = now; // don't repeat captures too foten
+                    break;
+                }
+            }
+        }
+    }
+
+    return status;
+}
+
+// Here we would typically add some critiera required to trigger a full capture
+// capture event.  We would do this selectively so that full frames are not
+// retrieved at each stage of processing. For example, if we want to capture a s
+// selfie image, we might monitor face positions over time to ensure that the
+// subject is relatively centered in the image and that there is fairly low
+// frame-to-frame motion.
+drishti_request_t FaceTrackTest::trigger(const drishti_face_tracker_result_t& faces, double timestamp, std::uint32_t tex)
+{
+    m_impl->logger->info("trigger: Received results at time {}}", timestamp);
+
+    if (m_impl->display)
+    {
+        m_impl->updatePreview(tex);
+    }
+
+    if (shouldCapture(faces))
+    {
+        return // Here we formulate the actual request, see drishti_request_t:
+            {
+                3,    // Retrieve the last N frames
+                true, // Get frames in user memory
+                true, // Get frames as texture ID's
+                true, // Get full frame images
+                true  // Get eye crop images
+            };
+    }
+
+    return { 0 }; // otherwise request nothing!
+}
+
+int FaceTrackTest::allocator(const drishti_image_t& spec, drishti::sdk::Image4b& image)
+{
+    m_impl->logger->info("allocator: {} {}", spec.width, spec.height);
+    return 0;
+}
+
+int FaceTrackTest::callbackFunc(void* context, drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results)
+{
+    if (FaceTrackTest* ft = static_cast<FaceTrackTest*>(context))
+    {
+        return ft->callback(results);
+    }
+    return -1;
+}
+
+drishti_request_t FaceTrackTest::triggerFunc(void* context, const drishti_face_tracker_result_t& faces, double timestamp, std::uint32_t tex)
+{
+    if (FaceTrackTest* ft = static_cast<FaceTrackTest*>(context))
+    {
+        return ft->trigger(faces, timestamp, tex);
+    }
+    return { 0, false, false };
+}
+
+int FaceTrackTest::allocatorFunc(void* context, const drishti_image_t& spec, drishti::sdk::Image4b& image)
+{
+    if (FaceTrackTest* ft = static_cast<FaceTrackTest*>(context))
+    {
+        return ft->allocator(spec, image);
+    }
+    return -1;
+}
+
+void FaceTrackTest::setSizeHint(const cv::Size& size)
+{
+    m_impl->size = size;
+}
+
+void FaceTrackTest::process(StackType& stack)
+{
+    for (int i = 0; i < stack.size(); i++)
+    {
+        auto& s = stack[i];
+        for (int j = 0; j < s.first.faceModels.size(); j++)
+        {
+            auto& f = s.first.faceModels[j];
+            draw(s.second, f);
+
+            std::stringstream ss;
+            ss << m_impl->output << "/aframe_" << std::setw(4) << std::setfill('0') << m_impl->counter << "_" << j << ".png";
+            cv::imwrite(ss.str(), s.second);
+        }
+    }
+    m_impl->counter++;
+}
+
+// Utility {
+
+void draw(cv::Mat& image, const drishti::sdk::Eye& eye)
+{
+    auto eyelids = drishti::sdk::drishtiToCv(eye.getEyelids());
+    auto crease = drishti::sdk::drishtiToCv(eye.getCrease());
+    auto pupil = drishti::sdk::drishtiToCv(eye.getPupil());
+    auto iris = drishti::sdk::drishtiToCv(eye.getIris());
+
+    cv::ellipse(image, iris, { 0, 255, 0 }, 1, 8);
+    cv::ellipse(image, pupil, { 0, 255, 0 }, 1, 8);
+    for (const auto& p : eyelids)
+    {
+        cv::circle(image, p, 2, { 0, 255, 0 }, -1, 8);
+    }
+    for (const auto& p : crease)
+    {
+        cv::circle(image, p, 2, { 0, 255, 0 }, -1, 8);
+    }
+}
+
+void draw(cv::Mat& image, const drishti::sdk::Face& face)
+{
+    //    auto landmarks = drishti::sdk::drishtiToCv(face.landmarks);
+    //    for (const auto &p : landmarks)
+    //    {
+    //        cv::circle(image, p, 2, {0,255,0}, -1, 8);
+    //    }
+
+    for (const auto& e : face.eyes)
+    {
+        draw(image, e);
+    }
+}
+
+// }

--- a/src/app/face/FaceTrackerTest.h
+++ b/src/app/face/FaceTrackerTest.h
@@ -1,0 +1,69 @@
+/*!
+  @file   FaceTrackerTest.h
+  @author David Hirvonen
+  @brief  Sample eye/face tracking using drishti.
+
+  \copyright Copyright 2017-2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#ifndef __FaceTrackerTest_h__
+#define __FaceTrackerTest_h__
+
+#include <drishti/FaceTracker.hpp>
+#include <drishti/drishti_cv.hpp>
+
+#include <spdlog/spdlog.h> // for portable logging
+
+#include <memory>
+
+// See: https://github.com/elucideye/drishti/blob/master/src/lib/drishti/drishti/ut/test-FaceTracker.cpp
+class FaceTrackTest
+{
+public:
+    using StackType = std::vector<std::pair<drishti_face_tracker_result_t, cv::Mat>>;
+
+    FaceTrackTest(std::shared_ptr<spdlog::logger>& logger, const std::string& sOutput);
+    ~FaceTrackTest();
+
+    // Callback definitions: {
+    int allocator(const drishti_image_t& spec, drishti::sdk::Image4b& image);
+    static int allocatorFunc(void* context, const drishti_image_t& spec, drishti::sdk::Image4b& image);
+
+    int callback(drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results);
+    static int callbackFunc(void* context, drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results);
+
+    drishti_request_t trigger(const drishti_face_tracker_result_t& faces, double timestamp, std::uint32_t tex);
+    static drishti_request_t triggerFunc(void* context, const drishti_face_tracker_result_t& faces, double timestamp, std::uint32_t tex);
+    // }
+
+    // A user definable stack operation, with a default implementatino that performs
+    // simple logging for the purpose of illustration.
+    virtual void process(StackType& stack);
+
+    // Logging: {
+    void setCaptureSphere(const std::array<float, 3>& center, float radius, double seconds);
+    bool shouldCapture(const drishti_face_tracker_result_t& faces);
+    // }
+
+    // Utility methods: {
+    void initPreview(const cv::Size& size, GLenum textureFormat);
+    void setPreviewGeometry(float tx, float ty, float sx, float sy);
+    void setSizeHint(const cv::Size& size);
+    // }
+
+    // Define the public callback table:
+    drishti_face_tracker_t table{
+        this,
+        triggerFunc,
+        callbackFunc,
+        allocatorFunc
+    };
+
+protected:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+#endif // __FaceTrackerTest_h__

--- a/src/app/face/VideoCaptureList.cpp
+++ b/src/app/face/VideoCaptureList.cpp
@@ -1,0 +1,136 @@
+#include "VideoCaptureList.h"
+
+#include <fstream>
+#include <memory>
+
+// https://stackoverflow.com/a/1567703
+class Line
+{
+    std::string data;
+
+public:
+    friend std::istream& operator>>(std::istream& is, Line& l)
+    {
+        std::getline(is, l.data);
+        return is;
+    }
+    operator std::string() const { return data; }
+};
+
+namespace ext
+{
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+}
+
+static void expand(const std::string& filename, std::vector<std::string>& filenames)
+{
+    // Create input file list (or single image)
+    filenames = { filename };
+    if (filename.find(".txt") != std::string::npos)
+    {
+        std::ifstream ifs(filename);
+        if (ifs)
+        {
+            filenames.clear();
+            std::copy(std::istream_iterator<Line>(ifs), std::istream_iterator<Line>(), std::back_inserter(filenames));
+        }
+        else
+        {
+            throw std::runtime_error("Unable to open file: " + filename);
+        }
+    }
+}
+
+struct VideoCaptureList::Impl
+{
+    Impl(const std::string& filename)
+    {
+        expand(filename, filenames);
+        init();
+    }
+
+    Impl(const std::vector<std::string>& filenames)
+        : filenames(filenames)
+    {
+        init();
+    }
+
+    void next()
+    {
+        image = (++iter == filenames.end()) ? cv::imread(*iter) : cv::Mat();
+    }
+
+    void init()
+    {
+        iter = filenames.begin();
+        image = cv::imread(*iter);
+    }
+
+    cv::Mat image;
+    std::vector<std::string> filenames;
+    std::vector<std::string>::iterator iter;
+};
+
+VideoCaptureList::VideoCaptureList(const std::string& filename)
+{
+    m_impl = ext::make_unique<Impl>(filename);
+}
+
+VideoCaptureList::VideoCaptureList(const std::vector<std::string>& filenames)
+{
+    m_impl = ext::make_unique<Impl>(filenames);
+}
+
+VideoCaptureList::~VideoCaptureList() = default;
+
+bool VideoCaptureList::grab()
+{
+    return false;
+}
+
+bool VideoCaptureList::isOpened() const
+{
+    return m_impl->filenames.size() > 0;
+}
+
+void VideoCaptureList::release()
+{
+    m_impl->filenames.clear();
+    m_impl->image.release();
+}
+
+bool VideoCaptureList::open(const cv::String& filename)
+{
+    m_impl = ext::make_unique<Impl>(filename);
+    return !m_impl->image.empty();
+}
+
+bool VideoCaptureList::read(cv::OutputArray image)
+{
+    if (m_impl->iter != m_impl->filenames.end())
+    {
+        image.assign(m_impl->image);
+        m_impl->next();
+        return true;
+    }
+    return false;
+}
+
+double VideoCaptureList::get(int propId) const
+{
+    switch (propId)
+    {
+        case CV_CAP_PROP_FRAME_WIDTH:
+            return static_cast<double>(m_impl->image.cols);
+        case CV_CAP_PROP_FRAME_HEIGHT:
+            return static_cast<double>(m_impl->image.rows);
+        case CV_CAP_PROP_FRAME_COUNT:
+            return static_cast<double>(m_impl->filenames.size());
+        default:
+            return 0.0;
+    }
+}

--- a/src/app/face/VideoCaptureList.cpp
+++ b/src/app/face/VideoCaptureList.cpp
@@ -1,6 +1,8 @@
 #include "VideoCaptureList.h"
 
 #include <fstream>
+#include <istream>
+#include <iterator>
 #include <memory>
 
 // https://stackoverflow.com/a/1567703
@@ -17,13 +19,13 @@ public:
     operator std::string() const { return data; }
 };
 
-namespace ext
+namespace detail
 {
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args)
-{
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
+    template <typename T, typename... Args>
+    std::unique_ptr<T> make_unique(Args&&... args)
+    {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
 }
 
 static void expand(const std::string& filename, std::vector<std::string>& filenames)
@@ -77,12 +79,12 @@ struct VideoCaptureList::Impl
 
 VideoCaptureList::VideoCaptureList(const std::string& filename)
 {
-    m_impl = ext::make_unique<Impl>(filename);
+    m_impl = detail::make_unique<Impl>(filename);
 }
 
 VideoCaptureList::VideoCaptureList(const std::vector<std::string>& filenames)
 {
-    m_impl = ext::make_unique<Impl>(filenames);
+    m_impl = detail::make_unique<Impl>(filenames);
 }
 
 VideoCaptureList::~VideoCaptureList() = default;
@@ -105,7 +107,7 @@ void VideoCaptureList::release()
 
 bool VideoCaptureList::open(const cv::String& filename)
 {
-    m_impl = ext::make_unique<Impl>(filename);
+    m_impl = detail::make_unique<Impl>(filename);
     return !m_impl->image.empty();
 }
 

--- a/src/app/face/VideoCaptureList.h
+++ b/src/app/face/VideoCaptureList.h
@@ -1,4 +1,5 @@
 #include <opencv2/highgui.hpp>
+#include <memory>
 
 #ifndef __VideoCaptureList_h__
 #define __VideoCaptureList_h__

--- a/src/app/face/VideoCaptureList.h
+++ b/src/app/face/VideoCaptureList.h
@@ -1,0 +1,23 @@
+#include <opencv2/highgui.hpp>
+
+#ifndef __VideoCaptureList_h__
+#define __VideoCaptureList_h__
+
+class VideoCaptureList : public cv::VideoCapture
+{
+public:
+    VideoCaptureList(const std::string& filename);
+    VideoCaptureList(const std::vector<std::string>& filenames);
+    virtual ~VideoCaptureList();
+    virtual bool grab();
+    virtual bool isOpened() const;
+    virtual void release();
+    virtual bool open(const cv::String& filename);
+    virtual bool read(cv::OutputArray image);
+    double get(int propId) const;
+
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+#endif // __VideoCaptureList_h__

--- a/src/app/face/drishti-face-test.cpp
+++ b/src/app/face/drishti-face-test.cpp
@@ -8,6 +8,11 @@
 
 */
 
+// Need std:: extensions for android targets
+#if defined(DRISHTI_HUNTER_TEST_ADD_TO_STRING)
+#  include "stdlib_string.h"
+#endif
+
 #include <spdlog/spdlog.h> // for portable logging
 #include <spdlog/fmt/ostr.h>
 

--- a/src/app/face/drishti-face-test.cpp
+++ b/src/app/face/drishti-face-test.cpp
@@ -8,15 +8,14 @@
 
 */
 
-#include <drishti/FaceTracker.hpp>
-#include <drishti/drishti_cv.hpp>
-
-#include <spdlog/spdlog.h> // for portable loggin
+#include <spdlog/spdlog.h> // for portable logging
 #include <spdlog/fmt/ostr.h>
 
+#include "FaceTrackerTest.h"
 #include "FaceTrackerFactoryJson.h"
+#include "VideoCaptureList.h"
 
-#include <opencv2/core.hpp> // for cv::Mat
+#include <opencv2/core.hpp>    // for cv::Mat
 #include <opencv2/imgproc.hpp> // for cv::cvtColor()
 #include <opencv2/highgui.hpp> // for cv::imread()
 
@@ -37,198 +36,36 @@
 #endif
 // clang-format on
 
-// https://stackoverflow.com/a/1567703
-class Line
-{
-    std::string data;
-public:
-    friend std::istream &operator>>(std::istream &is, Line &l)
-    {
-        std::getline(is, l.data);
-        return is;
-    }
-    operator std::string() const { return data; }
-};
-
 using FaceResources = drishti::sdk::FaceTracker::Resources;
+static std::shared_ptr<cv::VideoCapture> create(const std::string& filename);
+static std::shared_ptr<spdlog::logger> createLogger(const char* name);
+static cv::Size getSize(const cv::VideoCapture& video);
 
-static std::shared_ptr<spdlog::logger> createLogger(const char *name);
-static std::shared_ptr<drishti::sdk::FaceTracker> create(FaceResources &factory, const cv::Size& size, int orientation, float fx);
-
-// See: https://github.com/elucideye/drishti/blob/master/src/lib/drishti/drishti/ut/test-FaceTracker.cpp
-struct FaceTrackTest
-{
-    FaceTrackTest(std::shared_ptr<spdlog::logger> &logger, const std::string &sOutput)
-        : m_logger(logger)
-        , m_output(sOutput)
-        , m_counter(0)
-    {
-        table =
-        {
-            this,
-            triggerFunc,
-            callbackFunc,
-            allocatorFunc
-        };
-    }
-    
-    static void draw(cv::Mat &image, const drishti::sdk::Eye &eye)
-    {
-        auto eyelids = drishti::sdk::drishtiToCv(eye.getEyelids());
-        auto crease = drishti::sdk::drishtiToCv(eye.getCrease());
-        auto pupil = drishti::sdk::drishtiToCv(eye.getPupil());
-        auto iris = drishti::sdk::drishtiToCv(eye.getIris());
-        
-        cv::ellipse(image, iris, {0,255,0}, 1, 8);
-        cv::ellipse(image, pupil, {0,255,0}, 1, 8);
-        for (const auto &p : eyelids)
-        {
-            cv::circle(image, p, 2, {0,255,0}, -1, 8);
-        }
-        for (const auto &p : crease)
-        {
-            cv::circle(image, p, 2, {0,255,0}, -1, 8);
-        }
-    }
-    
-    static void draw(cv::Mat &image, const drishti::sdk::Face &face)
-    {
-        auto landmarks = drishti::sdk::drishtiToCv(face.landmarks);
-        for (const auto &p : landmarks)
-        {
-            cv::circle(image, p, 2, {0,255,0}, -1, 8);
-        }
-        
-        for (const auto &e : face.eyes)
-        {
-            draw(image, e);
-        }
-    }
-    
-    void setSizeHint(const cv::Size &size)
-    {
-        m_size = size;
-    }
-
-    int callback(drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results)
-    {
-        m_logger->info("callback: Received results");
-        
-        if(results.size() > 0)
-        {
-            const auto &r = results[0];
-            {
-                cv::Mat canvas;
-                if(r.image.image.getRows() > 0 && r.image.image.getCols() > 0)
-                {
-                    // Use the actual image as a canvas if it was requested ...
-                    canvas = drishti::sdk::drishtiToCv<drishti::sdk::Vec4b, cv::Vec4b>(r.image.image).clone();
-                }
-                else
-                {
-                    // ... otherwise we create an empty image for this
-                    canvas = cv::Mat::zeros(m_size.height, m_size.width, CV_8UC3);
-                }
-                
-                for (const auto &f : r.faceModels)
-                {
-                    draw(canvas, f);
-                }
-                
-                std::stringstream ss;
-                ss << m_output << "/frame_" << std::setw(4) << std::setfill('0') << m_counter++ << ".png";
-                
-                cv::imwrite(ss.str(), canvas);
-            }
-        }
-        
-        return 0;
-    }
-
-    // Here we would typically add some critiera required to trigger a full capture
-    // capture event.  We would do this selectively so that full frames are not
-    // retrieved at each stage of processing. For example, if we want to capture a s
-    // selfie image, we might monitor face positions over time to ensure that the
-    // subject is relatively centered in the image and that there is fairly low
-    // frame-to-frame motion.
-    drishti_request_t trigger(const drishti_face_tracker_result_t& faces, double timestamp)
-    {
-        m_logger->info("trigger: Received results at time {}}", timestamp);
-
-        if(faces.faceModels.size())
-        {
-            // Here for formulate the actual request, see drishti_request_t:
-            // 1) Retrieve the last N frames (1)
-            // 2) Get frames in user memory (true)
-            // 3) Get frames as texture ID's (true)
-            // 4) Get full frame images (true)
-            // 5) Get eye crop images (true)
-            return { 1, true, true, true, true };
-        }
-        
-        return { 0 };
-    }
-    
-    int allocator(const drishti_image_t& spec, drishti::sdk::Image4b& image)
-    {
-        m_logger->info("allocator: {} {}", spec.width, spec.height);
-        return 0;
-    }
-    
-    static int callbackFunc(void* context, drishti::sdk::Array<drishti_face_tracker_result_t, 64>& results)
-    {
-        if (FaceTrackTest* ft = static_cast<FaceTrackTest*>(context))
-        {
-            return ft->callback(results);
-        }
-        return -1;
-    }
-    
-    static drishti_request_t triggerFunc(void* context, const drishti_face_tracker_result_t& faces, double timestamp)
-    {
-        if (FaceTrackTest* ft = static_cast<FaceTrackTest*>(context))
-        {
-            return ft->trigger(faces, timestamp);
-        }
-        return { 0, false, false };
-    }
-    
-    static int allocatorFunc(void* context, const drishti_image_t& spec, drishti::sdk::Image4b& image)
-    {
-        if (FaceTrackTest* ft = static_cast<FaceTrackTest*>(context))
-        {
-            return ft->allocator(spec, image);
-        }
-        return -1;
-    }
-
-    drishti_face_tracker_t table;
-
-    std::shared_ptr<spdlog::logger> m_logger;
-    std::string m_output;
-    std::size_t m_counter;
-    
-    cv::Size m_size; // video resolution
-};
-
-int gauze_main(int argc, char **argv)
+int gauze_main(int argc, char** argv)
 {
     const auto argumentCount = argc;
 
+    bool doPreview = false, doTurbo = false, doCapture = false;
     std::string sInput, sOutput, sModels;
+    float fx = 0.f, minZ = 0.f, maxZ = 0.f, calibration = 0.0;
 
-    float fx = 0.f;
-    
     cxxopts::Options options("drishti-face-test", "Command line interface for face model fitting");
-    
+
     // clang-format off
     options.add_options()
         // input/output:
         ("i,input", "Input image", cxxopts::value<std::string>(sInput))
         ("f,focal-length", "focal length", cxxopts::value<float>(fx))
+        ("min", "Closest object distance", cxxopts::value<float>(minZ))
+        ("max", "Farthest object distance", cxxopts::value<float>(maxZ))
+        ("c,calibration", "ACF detection calibration term", cxxopts::value<float>(calibration))
         ("o,output", "Output image", cxxopts::value<std::string>(sOutput))
-        ("m,models", "Model factory configuration file (JSON)", cxxopts::value<std::string>(sModels));
-    // clang-format on    
+        ("m,models", "Model factory configuration file (JSON)", cxxopts::value<std::string>(sModels))
+        ("capture", "Perform capture every 8 seconds in central capture volume", cxxopts::value<bool>(doCapture))
+        ("turbo", "Run the optimized pipeline (adds a little latency)", cxxopts::value<bool>(doTurbo))
+        ("p,preview", "Preview window", cxxopts::value<bool>(doPreview))
+    ;
+    // clang-format on
 
     options.parse(argc, argv);
     if ((argumentCount <= 1) || options.count("help"))
@@ -238,7 +75,7 @@ int gauze_main(int argc, char **argv)
     }
 
     auto logger = createLogger("drishti-face-test");
-    
+
     if (sInput.empty())
     {
         logger->error("Must specify input {}", sInput);
@@ -257,90 +94,172 @@ int gauze_main(int argc, char **argv)
         return 1;
     }
 
+    if (options.count("focal-length") != 1)
+    {
+        logger->error("Must specify focal length (in pixels)");
+        return 1;
+    }
+
+    if (options.count("min") != 1)
+    {
+        logger->error("Must specify closest object distance");
+        return 1;
+    }
+
+    if (options.count("max") != 1)
+    {
+        logger->error("Must specify farthest object distance");
+        return 1;
+    }
+
+    if (minZ > maxZ)
+    {
+        logger->error("Search range requires minZ < maxZ");
+        return 1;
+    }
+
     FaceTrackerFactoryJson factory(sModels, "drishti-face-test");
 
-    // Create input file list (or single image)
-    std::vector<std::string> lines = { sInput };
-    if(sInput.find(".txt") != std::string::npos)
+    // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    // Allocate a video source and get the video frame dimensions:
+    // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    auto video = create(sInput);
+    if (!video)
     {
-        std::ifstream ifs(sInput);
-        if(ifs)
-        {
-            lines.clear();
-            std::copy(std::istream_iterator<Line>(ifs), std::istream_iterator<Line>(), std::back_inserter(lines));
-        }
+        logger->error("Failed to create video source for {}", sInput);
+        return 1;
     }
-    
-    auto glContext = aglet::GLContext::create(aglet::GLContext::kAuto);
+    cv::Size size = getSize(*video);
+
+    // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    // Create an OpenGL context (w/ optional window):
+    // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    std::shared_ptr<aglet::GLContext> glContext;
+    if (doPreview)
+    {
+        glContext = aglet::GLContext::create(aglet::GLContext::kAuto, "drishti-face-test", size.width, size.height);
+    }
+    else
+    {
+        glContext = aglet::GLContext::create(aglet::GLContext::kAuto);
+    }
+
     if (!glContext)
     {
         logger->error("Failed to create OpenGL context");
         return 1;
     }
-    
+
     (*glContext)();
-    
-    FaceTrackTest context(logger, sOutput);
-    
+
+    // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    // Instantiate face tracking callbacks:
+    // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
     std::shared_ptr<drishti::sdk::FaceTracker> tracker;
-    
-    cv::Size size;
-    for (const auto &filename : lines)
+
+    { // Configure the face tracker parameters:
+        drishti::sdk::Vec2f p(size.width / 2, size.height / 2);
+        drishti::sdk::SensorModel::Intrinsic intrinsic(p, fx, { size.width, size.height });
+        drishti::sdk::SensorModel::Extrinsic extrinsic(drishti::sdk::Matrix33f::eye());
+        drishti::sdk::SensorModel sensor(intrinsic, extrinsic);
+
+        drishti::sdk::Context context(sensor);
+        context.setDoSingleFace(true);          // only detect 1 face per frame
+        context.setMinDetectionDistance(minZ);  // min distance
+        context.setMaxDetectionDistance(maxZ);  // max distance
+        context.setFaceFinderInterval(0.f);     // detect on every frame ...
+        context.setAcfCalibration(calibration); // adjust detection sensitivity
+        context.setRegressorCropScale(1.1f);
+        context.setMinTrackHits(3);
+        context.setMaxTrackMisses(2);
+        context.setMinFaceSeparation(1.f);
+        context.setDoOptimizedPipeline(doTurbo);
+        context.setDoAnnotation(true); // add default annotations for quick preview
+
+        tracker = std::make_shared<drishti::sdk::FaceTracker>(&context, factory.factory);
+        if (!tracker)
+        {
+            logger->error("Failed to create face tracker");
+            return 1;
+        }
+    }
+
+    // Register callbacks:
+    FaceTrackTest context(logger, sOutput);
+    context.setSizeHint(size);
+    if (doPreview)
     {
-        cv::Mat image = cv::imread(filename, cv::IMREAD_COLOR);
+        context.initPreview(size, DFLT_TEXTURE_FORMAT);
+    }
+
+    if (doCapture)
+    {
+        // Set a capture volume on the camera's optical axis with a 1/3 meter radius
+        // and be sure not to trigger a capture more than once every 8.0 seconds.
+        context.setCaptureSphere({ { 0.f, 0.f, ((maxZ + minZ) / 2.0f) } }, 0.33f, 8.0);
+    }
+
+    tracker->add(context.table);
+
+    float resolution = 1.0f;
+
+    const auto tic = std::chrono::high_resolution_clock::now();
+
+    std::size_t index = 0;
+    std::function<bool()> process = [&]() {
+        cv::Mat image;
+        (*video) >> image;
+
         if (image.empty())
         {
             logger->error("Unable to read image {}", sInput);
-            continue;
+            return false;
         }
+
+        if (size.area() && (size != image.size()))
+        {
+            logger->error("Frame dimensions must be consistent: {}{}", size.width, size.height);
+        }
+
         if (image.channels() == 3)
         {
             cv::cvtColor(image, image, cv::COLOR_BGR2BGRA);
         }
-        
-        if (!tracker)
-        {
-            if(fx == 0.f)
-            {
-                fx = image.cols; // guess
-            }
-            tracker = create(factory.factory, image.size(), 0, fx);
-            if (!tracker)
-            {
-                logger->error("Failed to create face tracker");
-                return 1;
-            }
-            
-            // Register callbacks:
-            tracker->add(context.table);
-            
-            context.setSizeHint(image.size());
+
+        if (doPreview)
+        { // Update window properties (if used):
+            auto& win = glContext->getGeometry();
+            context.setPreviewGeometry(win.tx, win.ty, win.sx * resolution, win.sy * resolution);
         }
-        
-        logger->info("Frame: {}", filename);
-        
-        if(size.area() && size != image.size())
-        {
-            logger->error("Frame dimensions must be consistent: {}{}", size.width, size.height);
-            continue;
-        }
-        
+
         // Register callback:
         drishti::sdk::VideoFrame frame({ image.cols, image.rows }, image.ptr(), true, 0, DFLT_TEXTURE_FORMAT);
         (*tracker)(frame);
-    }
+
+        // Comnpute simple/global FPS
+        const auto toc = std::chrono::high_resolution_clock::now();
+        const double elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(toc - tic).count();
+        const double fps = static_cast<double>(index + 1) / elapsed;
+
+        logger->info("Frame: {} fps = {}", index++, fps);
+
+        return true;
+    };
+
+    (*glContext)(process);
 
     return 0;
 }
 
 #if !defined(DRISHTI_TEST_BUILD_TESTS)
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     try
     {
         return gauze_main(argc, argv);
     }
-    catch(const std::exception &e)
+    catch (const std::exception& e)
     {
         std::cerr << "Exception: " << e.what() << std::endl;
         return 1;
@@ -350,37 +269,7 @@ int main(int argc, char **argv)
 }
 #endif
 
-/*
- * FaceFinder configuration can be achieved by modifying the input
- * configurations stored as member variables in the test fixture prior
- * to calling create()
- * 
- * @param size  : size of input frames for detector
- * @orientation : orientation of input frames
- */
-std::shared_ptr<drishti::sdk::FaceTracker> create(FaceResources &factory, const cv::Size& size, int orientation, float fx)
-{
-    drishti::sdk::Vec2f p(size.width/2, size.height/2);
-    drishti::sdk::SensorModel::Intrinsic intrinsic(p, fx, {size.width, size.height});
-    drishti::sdk::SensorModel::Extrinsic extrinsic(drishti::sdk::Matrix33f::eye());
-    drishti::sdk::SensorModel sensor(intrinsic, extrinsic);
-
-    drishti::sdk::Context context(sensor);
-    context.setDoSingleFace(true);         // only detect 1 face per frame
-    context.setMinDetectionDistance(0.f);  // min distance
-    context.setMaxDetectionDistance(1.f);  // max distance
-    context.setFaceFinderInterval(0.f);    // detect on every frame ...
-    context.setAcfCalibration(0.001f);     // adjust detection sensitivity
-    context.setRegressorCropScale(1.f);
-    context.setMinTrackHits(1);
-    context.setMaxTrackMisses(1);
-    context.setMinFaceSeparation(1.f);
-    context.setDoOptimizedPipeline(false); // no latency
-    
-    return std::make_shared<drishti::sdk::FaceTracker>(&context, factory);
-}
-
-static std::shared_ptr<spdlog::logger> createLogger(const char *name)
+static std::shared_ptr<spdlog::logger> createLogger(const char* name)
 {
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
@@ -392,3 +281,27 @@ static std::shared_ptr<spdlog::logger> createLogger(const char *name)
     spdlog::set_pattern("[%H:%M:%S.%e | thread:%t | %n | %l]: %v");
     return logger;
 }
+
+static std::shared_ptr<cv::VideoCapture> create(const std::string& filename)
+{
+    if (filename.find_first_not_of("0123456789") == std::string::npos)
+    {
+        return std::make_shared<cv::VideoCapture>(std::stoi(filename));
+    }
+    else if (filename.find(".txt") != std::string::npos)
+    {
+        return std::make_shared<VideoCaptureList>(filename);
+    }
+    else
+    {
+        return std::make_shared<cv::VideoCapture>(filename);
+    }
+}
+
+static cv::Size getSize(const cv::VideoCapture& video)
+{
+    return {
+        static_cast<int>(video.get(cv::CAP_PROP_FRAME_WIDTH)),
+        static_cast<int>(video.get(cv::CAP_PROP_FRAME_HEIGHT))
+    };
+};


### PR DESCRIPTION
* standardize input on cv::VideoCapture api, provide VideoCaptureStills (list of files)
* add live preview of input stream
* add worker thread for stack logging example
* update drishti submodule (3d face position update)
* add ogles_gpgpu submodule (OPENGL_ES3 header fix on osx)
* add position based capture trigger in user defined 3D sphere (`—capture`)
* add “DRISHTI_OPENGL_ES3” option
  + option: DHT_OGLES_GPGPU_AS_SUBMODULE
  + option: DHT_DRISHTI_AS_SUBMODULE
  + pass down DRISHTI_OPENGL_ES3 to drishti, aglet, ogles_gpgpu (consistent version) in hunter_config()
* clang-format everything